### PR TITLE
# 游戏无法进入

### DIFF
--- a/game-server/app/util/dispatcher.js
+++ b/game-server/app/util/dispatcher.js
@@ -1,7 +1,7 @@
 var crc = require('crc');
 
 module.exports.dispatch = function(uid, connectors) {
-	var index = Math.abs(parseInt(crc.crc32(uid)),16) % connectors.length;
-	return connectors[index];
+    var index = Math.abs(parseInt(crc.crc32(uid),16)) % connectors.length;
+    return connectors[index];
 };
 

--- a/game-server/package.json
+++ b/game-server/package.json
@@ -3,7 +3,7 @@
   "version": "0.2.0",
   "private": false,
   "dependencies": {
-    "pomelo":"0.4.3"
+    "pomelo":"1.1.6"
     , "crc" : ">=0.0.1"
     , "pomelo-collection": ">=0.1.0"
     , "pomelo-logger": "0.0.2" 


### PR DESCRIPTION
在跑 Treasures 这个 demo 的时候，会发现打开网页的 ”start game“ 按钮没反应，经排查发现是

web-server/public/js/main.js 中的 pomelo.request(‘area.playerHandler.getAnimation’ 没有执行。

解决办法是，在命令行中查询 pomelo 最新版本号：

$ pomelo —version

然后更新 game-server/package.json 中的 dependencies.pomelo 为最新版本，接着重新安装依赖：

$ sudo sh npm-install.sh

最后重启应用即可。

# 进入游戏后无法捡宝

进入游戏后是捡宝物，但点宝物无反应，控制台还报错。
问题出在  game-server/app/util/dispatcher.js 中
var index = Math.abs(parseInt(crc.crc32(uid)),16) % connectors.length;
应改为：
var index = Math.abs(parseInt(crc.crc32(uid),16)) % connectors.length;
改完后重启应用即可。