### PR TITLE
add mime version number

### DIFF
--- a/web-server/package.json
+++ b/web-server/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "private": false,
   "dependencies": {
-    "express": "2.5.2"
+    "express": "2.5.2",
+    "mime": "^1"
   }
 }


### PR DESCRIPTION
最新的mime模块更新到了2.x版本，其中一些方法名称被修改或移除，导致正常安装模块依赖后，treasures中的mime相关代码报错，不能运行。所以在package.json增加mime版本限制，指定安装1.x版本。